### PR TITLE
Allow shutdowns to timeout

### DIFF
--- a/lib/kafka.rb
+++ b/lib/kafka.rb
@@ -355,6 +355,9 @@ module Kafka
   class TokenMethodNotImplementedError < Error
   end
 
+  class AsyncProducerIsClosed < Error
+  end
+
   # Initializes a new Kafka client.
   #
   # @see Client#initialize

--- a/lib/kafka/async_producer.rb
+++ b/lib/kafka/async_producer.rb
@@ -149,6 +149,7 @@ module Kafka
     def shutdown(timeout=nil)
       ensure_threads_running!
 
+      @queue.close
       @worker.flip_shutdown_latch!
       @timer_thread && @timer_thread.exit
 

--- a/lib/kafka/async_producer.rb
+++ b/lib/kafka/async_producer.rb
@@ -117,7 +117,12 @@ module Kafka
       end
 
       args = [value, **options.merge(topic: topic)]
-      @queue << [:produce, args]
+
+      begin
+        @queue << [:produce, args]
+      rescue ClosedQueueError
+        raise Kafka::AsyncProducerIsClosed
+      end
 
       @instrumenter.instrument("enqueue_message.async_producer", {
         topic: topic,

--- a/lib/kafka/async_producer.rb
+++ b/lib/kafka/async_producer.rb
@@ -146,15 +146,20 @@ module Kafka
     #
     # @see Kafka::Producer#shutdown
     # @return [nil]
-    def shutdown
+    def shutdown(timeout=nil)
       ensure_threads_running!
 
+      @worker.flip_shutdown_latch!
       @timer_thread && @timer_thread.exit
-      @queue << [:shutdown, nil]
-      @worker_thread && @worker_thread.join
 
+      @worker_thread && @worker_thread.join(timeout)
       nil
     end
+
+    def shutdown?
+      !worker_thread_alive? && !timer_thread_alive?
+    end
+
 
     private
 
@@ -210,6 +215,11 @@ module Kafka
         @instrumenter = instrumenter
         @logger = TaggedLogger.new(logger)
         @finally = finally
+        @shutdown_latch = false
+      end
+
+      def flip_shutdown_latch!
+        @shutdown_latch = true
       end
 
       def run
@@ -240,44 +250,21 @@ module Kafka
 
       def do_loop
         loop do
-          begin
-            operation, payload = @queue.pop
+          if @shutdown_latch
+            shutdown
+            break
+          end
 
-            case operation
-            when :produce
-              produce(payload[0], **payload[1])
-              deliver_messages if threshold_reached?
-            when :deliver_messages
-              deliver_messages
-            when :shutdown
-              begin
-                # Deliver any pending messages first.
-                @producer.deliver_messages
-              rescue Error => e
-                @logger.error("Failed to deliver messages during shutdown: #{e.message}")
+          operation, payload = @queue.pop
 
-                @instrumenter.instrument("drop_messages.async_producer", {
-                  message_count: @producer.buffer_size + @queue.size,
-                })
-
-                if @finally
-                  @queue.close
-                  messages = []
-                  @queue.size.times do
-                    operation, payload = @queue.pop()
-                    if !payload.nil?
-                      messages << payload
-                    end
-                  end
-                  @finally.call(messages)
-                end
-              end
-
-              # Stop the run loop.
-              break
-            else
-              raise "Unknown operation #{operation.inspect}"
-            end
+          case operation
+          when :produce
+            produce(payload[0], **payload[1])
+            deliver_messages if threshold_reached?
+          when :deliver_messages
+            deliver_messages
+          else
+            raise "Unknown operation #{operation.inspect}"
           end
         end
       rescue Kafka::Error => e
@@ -286,6 +273,29 @@ module Kafka
 
         sleep 10
         retry
+      end
+
+      def shutdown
+        # Deliver any pending messages first.
+        @producer.deliver_messages
+      rescue Error => e
+        @logger.error("Failed to deliver messages during shutdown: #{e.message}")
+
+        @instrumenter.instrument("drop_messages.async_producer", {
+          message_count: @producer.buffer_size + @queue.size,
+        })
+
+        if @finally
+          @queue.close
+          messages = []
+          @queue.size.times do
+            operation, payload = @queue.pop()
+            if !payload.nil?
+              messages << payload
+            end
+          end
+          @finally.call(messages)
+        end
       end
 
       def produce(value, **kwargs)

--- a/lib/kafka/async_producer.rb
+++ b/lib/kafka/async_producer.rb
@@ -146,7 +146,7 @@ module Kafka
     #
     # @see Kafka::Producer#shutdown
     # @return [nil]
-    def shutdown(timeout=nil)
+    def shutdown(timeout = nil)
       ensure_threads_running!
 
       @queue.close
@@ -160,7 +160,6 @@ module Kafka
     def shutdown?
       !worker_thread_alive? && !timer_thread_alive?
     end
-
 
     private
 

--- a/spec/async_producer_spec.rb
+++ b/spec/async_producer_spec.rb
@@ -75,6 +75,18 @@ describe Kafka::AsyncProducer do
   end
 
   describe "#shutdown" do
+    it "times out if a timeout is set" do
+      sleep_time = 100
+      allow(sync_producer).to receive(:buffer_size) { 42 }
+      allow(sync_producer).to receive(:deliver_messages) { sleep(sleep_time) }
+
+      start_time = Time.now
+      async_producer.shutdown(0)
+      end_time = Time.now
+
+      expect(end_time - start_time < sleep_time)
+    end
+
     it "delivers buffered messages" do
       async_producer.produce("hello", topic: "greetings")
       async_producer.shutdown

--- a/spec/async_producer_spec.rb
+++ b/spec/async_producer_spec.rb
@@ -109,6 +109,12 @@ describe Kafka::AsyncProducer do
   end
 
   describe "#produce" do
+    it "raises an exception if trying to produce after shutdown" do
+      async_producer.shutdown
+      expect {
+        async_producer.produce("hello", topic: "greetings")
+      }.to raise_exception(Kafka::AsyncProducerIsClosed)
+    end
     it "delivers buffered messages" do
       async_producer.produce("hello", topic: "greetings")
       sleep 0.2 # wait for worker to call produce

--- a/spec/async_producer_spec.rb
+++ b/spec/async_producer_spec.rb
@@ -104,7 +104,7 @@ describe Kafka::AsyncProducer do
       expect(log.string).to include "Failed to deliver messages during shutdown: uh-oh!"
 
       metric = instrumenter.metrics_for("drop_messages.async_producer").first
-      expect(metric.payload[:message_count]).to eq 42
+      expect(metric.payload[:message_count]).to eq 43 # plus the produced message
     end
   end
 


### PR DESCRIPTION
And also shortcut the shutdown signal to the async worker, so that we can set a more reasonable bounds on shutdown time.