### PR TITLE
Handle nil operation in async_producer by starting shutdown

### DIFF
--- a/lib/kafka/async_producer.rb
+++ b/lib/kafka/async_producer.rb
@@ -268,6 +268,10 @@ module Kafka
             deliver_messages if threshold_reached?
           when :deliver_messages
             deliver_messages
+          when nil
+            # will be nil after the queue is closed, so we should shutdown in this case
+            shutdown
+            break
           else
             raise "Unknown operation #{operation.inspect}"
           end


### PR DESCRIPTION
```
mark.rada@BZ-C02D60ZWMD6V ~/Developer/ruby-kafka                                                                                                                                                                                                        [10:39:23] 
(k8s.cluster-001.s-aze-us.braze.com-opsengineer:default)> $ irb                                                                                                                                                                      [±closed-queue-returns-nil ✓]
irb(main):001:0> q = Queue.new
=> #<Thread::Queue:0x00007ffd0185c518>
irb(main):002:0> q.close
=> #<Thread::Queue:0x00007ffd0185c518>
irb(main):003:0> q.pop
=> nil
irb(main):004:0> 
```