### PR TITLE
Allow the finally handler to be configured through convenience constructors

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -326,6 +326,8 @@ module Kafka
     #   buffered messages that will automatically trigger a delivery.
     # @param delivery_interval [Integer] if greater than zero, the number of
     #   seconds between automatic message deliveries.
+    # @param finally [Proc] handler to deal with messages when they cannot be
+    #   delivered to producers (e.g. timeout during shutdown)
     #
     # @see AsyncProducer
     # @return [AsyncProducer]

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -329,7 +329,7 @@ module Kafka
     #
     # @see AsyncProducer
     # @return [AsyncProducer]
-    def async_producer(delivery_interval: 0, delivery_threshold: 0, max_queue_size: 1000, max_retries: -1, retry_backoff: 0, **options)
+    def async_producer(delivery_interval: 0, delivery_threshold: 0, max_queue_size: 1000, max_retries: -1, retry_backoff: 0, finally: nil, **options)
       sync_producer = producer(**options)
 
       AsyncProducer.new(
@@ -341,6 +341,7 @@ module Kafka
         retry_backoff: retry_backoff,
         instrumenter: @instrumenter,
         logger: @logger,
+        finally: finally,
       )
     end
 

--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -284,6 +284,14 @@ module Kafka
       @pending_message_queue.clear
     end
 
+    # @note This will pull messages from buffers instead copying them
+    # @return [Array<Array(Object, Hash)>]
+    def extract_undelivered_messages!
+      extracted_messages = buffer_messages.map { |message| [message.value, { topic: message.topic }] }
+      clear_buffer
+      extracted_messages
+    end
+
     # Closes all connections to the brokers.
     #
     # @return [nil]

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -48,6 +48,15 @@ describe Kafka::Client do
     end
   end
 
+  describe "#async_producer" do
+    subject(:client) { described_class.new(**client_opts) }
+
+    it "propagates the 'finally' lambda to the correct constructors" do
+      async_producer = client.async_producer(finally: Proc.new { |_| })
+      expect(async_producer).to_not be_nil
+    end
+  end
+
   describe "#deliver_message" do
     subject(:client) { described_class.new(**client_opts) }
 


### PR DESCRIPTION
Since we use `async_producer` internally to create our producers, what was happening was that `finally` would get grouped in with `**options`, which was then passed to `producer`, which did not have a `finally` kwarg and did not specify `**options` to group all the extra kwargs.

I'm also exposing methods that extract all the data from the buffers so I can remove most of the hacks I added in platform for doing the same thing.

And finally, and maybe most importantly, it makes the async producer include the sync producer's buffered data when using the `finally` feature. This is critically important for actually collecting the data to backup. If there is data to backup in the async producer queue, then there will almost always be sync producer buffer data to backup as well. However, it is likely that the async producer queue will be empty most of the time when there is data in the sync producer buffer. 