### PR TITLE
Pass app_group_id back up in undelivered messages

### DIFF
--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -287,7 +287,7 @@ module Kafka
     # @note This will pull messages from buffers instead copying them
     # @return [Array<Array(Object, Hash)>]
     def extract_undelivered_messages!
-      extracted_messages = buffer_messages.map { |message| [message.value, { topic: message.topic }] }
+      extracted_messages = buffer_messages.map { |message| [message.value, { topic: message.topic, app_group_id: message.headers[:app_group_id] }] }
       clear_buffer
       extracted_messages
     end

--- a/lib/kafka/protocol/record.rb
+++ b/lib/kafka/protocol/record.rb
@@ -17,7 +17,7 @@ module Kafka
       )
         @key = key
         @value = value
-        @headers = headers.dup
+        @headers = headers
         @attributes = attributes
 
         @offset_delta = offset_delta

--- a/lib/kafka/protocol/record.rb
+++ b/lib/kafka/protocol/record.rb
@@ -17,8 +17,8 @@ module Kafka
       )
         @key = key
         @value = value
-        headers.delete(:app_group_id)
-        @headers = headers
+        @headers = headers.dup
+        @headers.delete(:app_group_id)
         @attributes = attributes
 
         @offset_delta = offset_delta

--- a/lib/kafka/protocol/record.rb
+++ b/lib/kafka/protocol/record.rb
@@ -18,7 +18,6 @@ module Kafka
         @key = key
         @value = value
         @headers = headers.dup
-        @headers.delete(:app_group_id)
         @attributes = attributes
 
         @offset_delta = offset_delta
@@ -43,6 +42,7 @@ module Kafka
         record_encoder.write_varint_bytes(@value)
 
         record_encoder.write_varint_array(@headers.to_a) do |header_key, header_value|
+          next if header_key == :app_group_id
           record_encoder.write_varint_string(header_key.to_s)
           record_encoder.write_varint_bytes(header_value.to_s)
         end

--- a/lib/kafka/version.rb
+++ b/lib/kafka/version.rb
@@ -2,5 +2,5 @@
 
 module Kafka
   # Braze forked the version at 1.5.0
-  VERSION = "1.5.0.2"
+  VERSION = "1.5.0.3"
 end

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -40,17 +40,17 @@ describe Kafka::Producer do
 
   describe "#extract_undelivered_messages!" do
     it "gets messages from the buffer" do
-      producer.produce('test', topic: 'test')
+      producer.produce('test', topic: 'test', headers: { app_group_id: 'bread' })
       allow(cluster).to receive(:partitions_for).with('test') { [1] }
       producer.send(:assign_partitions!)
       messages = producer.extract_undelivered_messages!
-      expect(messages).to eq([['test', { topic: 'test' }]])
+      expect(messages).to eq([['test', { topic: 'test', app_group_id: 'bread' }]])
     end
 
     it "gets messages from the pending message queue" do
-      producer.produce('test', topic: 'test')
+      producer.produce('test', topic: 'test', headers: { app_group_id: 'banana' })
       messages = producer.extract_undelivered_messages!
-      expect(messages).to eq([['test', { topic: 'test' }]])
+      expect(messages).to eq([['test', { topic: 'test', app_group_id: 'banana' }]])
     end
 
     it "clears buffers afterwards" do

--- a/spec/record_spec.rb
+++ b/spec/record_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+describe Kafka::Protocol::Record do
+  let(:encoded_io) { StringIO.new }
+  let(:encoder) { Kafka::Protocol::Encoder.new(encoded_io) }
+
+  it 'does not encode app_group_id headers' do
+    record = described_class.new(value: 'test', headers: { app_group_id: 'blueberry' })
+    record.encode(encoder)
+    expect(encoded_io.string['blueberry']).to be_nil
+  end
+
+  it 'does encode other headers' do
+    record = described_class.new(value: 'test', headers: { fruit: 'raspberry' })
+    record.encode(encoder)
+    expect(encoded_io.string['raspberry']).to_not be_nil
+  end
+end


### PR DESCRIPTION
Modifying the existing headers hash was nuking the needed data before it got captured, so we need a dupe.