### PR TITLE
[NOTIX] Properly skip over app_group_id headers

### DIFF
--- a/lib/kafka/protocol/record.rb
+++ b/lib/kafka/protocol/record.rb
@@ -41,8 +41,8 @@ module Kafka
         record_encoder.write_varint_string(@key)
         record_encoder.write_varint_bytes(@value)
 
-        record_encoder.write_varint_array(@headers.to_a) do |header_key, header_value|
-          next if header_key == :app_group_id
+        sent_headers = @headers.filter { |k, _| k != :app_group_id }.to_a
+        record_encoder.write_varint_array(sent_headers) do |header_key, header_value|
           record_encoder.write_varint_string(header_key.to_s)
           record_encoder.write_varint_bytes(header_value.to_s)
         end

--- a/lib/kafka/version.rb
+++ b/lib/kafka/version.rb
@@ -2,5 +2,5 @@
 
 module Kafka
   # Braze forked the version at 1.5.0
-  VERSION = "1.5.0.3"
+  VERSION = "1.5.0.4"
 end

--- a/spec/record_spec.rb
+++ b/spec/record_spec.rb
@@ -8,11 +8,19 @@ describe Kafka::Protocol::Record do
     record = described_class.new(value: 'test', headers: { app_group_id: 'blueberry' })
     record.encode(encoder)
     expect(encoded_io.string['blueberry']).to be_nil
+
+    decoder = Kafka::Protocol::Decoder.from_string(encoded_io.string)
+    decoded_record = Kafka::Protocol::Record.decode(decoder)
+    expect(decoded_record.headers).to be_empty
   end
 
   it 'does encode other headers' do
     record = described_class.new(value: 'test', headers: { fruit: 'raspberry' })
     record.encode(encoder)
     expect(encoded_io.string['raspberry']).to_not be_nil
+
+    decoder = Kafka::Protocol::Decoder.from_string(encoded_io.string)
+    decoded_record = Kafka::Protocol::Record.decode(decoder)
+    expect(decoded_record.headers).to eq({ "fruit" => "raspberry" })
   end
 end


### PR DESCRIPTION
Array length is written ahead of the array, so if we want
to skip over the app_group_id headers, then we need to filter
out the app_group_id header before writing the array length.